### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Mahmoud336u/Finance-Assistant/security/code-scanning/3](https://github.com/Mahmoud336u/Finance-Assistant/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted to least privilege.  
Best fix for this file is to define workflow-level permissions right under `on:` (or before `jobs:`), since there is only one job and no job-specific write needs shown.

For `.github/workflows/ci.yml`, add:

- `permissions:`
  - `contents: read`

This preserves existing functionality (`actions/checkout` requires `contents: read`) while preventing unnecessary write scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
